### PR TITLE
Updated the mod version in gradle.properties to 2.0.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 minecraft_version=1.7.10
-forge_version=10.13.2.1230
-mod_version=1.8.2
+forge_version=10.13.2.1286
+mod_version=2.0
 mod_group=dmillerw.remoteio
 mod_archive_name=RemoteIO
 mod_info_path=src/main/java/remoteio/common/lib/ModInfo.java


### PR DESCRIPTION
I also updated the Minecraft Forge version to 10.13.2.1286 since it's a more recent Minecraft Forge version than 10.13.2.1230. Although RemoteIO should still compile just fine on the 10.13.2.1286 Forge version.
